### PR TITLE
Unify EP section styling, add track platform icon blocks, and restructure About/Credits formatting

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1633,13 +1633,15 @@ input, select, textarea {
 		}
 
 /* Custom CSS for Individual songs */
-#pohl {
+#pohl, #imaginaryfriends, #rocio, #about {
 	max-width: 100%;
 	text-align: center;
 	background-color: #000000;
 }
 
-#pohl h2, #pohl h2.major {
+#pohl h2, #pohl h2.major,
+#imaginaryfriends h2, #imaginaryfriends h2.major,
+#rocio h2, #rocio h2.major {
 	color: #0196fd;
 	border-bottom: solid 1px #0196fd;
 	font-size: 33px;
@@ -1649,18 +1651,22 @@ input, select, textarea {
 	/* background-size: cover; */
 }
 
-#pohl p {
+#pohl p,
+#imaginaryfriends p,
+#rocio p {
 	color: #0196fd;
-	font-size: 20px;
+	font-size: 14pt;
 	text-align: right;
-	padding-left: 25%;
-	padding-right: 25%;
+	padding-left: 10%;
+	padding-right: 10%;
+	margin: 0 0 .66em 0;
 	max-width: auto;
-	min-height: auto;
+	/* min-height: auto; */
 	text-align: center;
   }
 
-  #pohl ul, ul.icons li a {
+  #pohl ul, #imaginaryfriends ul,
+  #rocio ul, ul.icons li a {
 	color: #0196fd;
 	box-shadow: none;
 	text-align: center;
@@ -1669,65 +1675,6 @@ input, select, textarea {
 	min-height: auto;
 	font-size: 133%;
   }
-
-#imaginaryfriends {
-	max-width: 100%;
-	text-align: center;
-	background-color: #000000;
-}
-
-#imaginaryfriends h2, #imaginaryfriends h2.major {
-	color: #0196fd;
-	border-bottom: solid 1px #0196fd;
-	font-size: 33px;
-	display: inline;
-	text-align: center;
-	background-size: cover;
-}
-
-#imaginaryfriends p {
-	color: #0196fd;
-	font-size: 20px;
-	text-align: right;
-	padding-left: 7%;
-	padding-right: 12%;
-	text-wrap:initial;
-	max-width: auto;
-	min-height: auto;
-	text-align: center;
-  }
-
-#rocio {
-	max-width: 100%;
-	text-align: center;
-	background-color: #000000;
-}
-
-#rocio h2, #rocio h2.major {
-	color: #0196fd;
-	border-bottom: solid 1px #0196fd;
-	font-size: 33px;
-	display: inline;
-	text-align: center;
-	background-size: cover;
-}
-
-#rocio p {
-	color: #0196fd;
-	font-size: 20px;
-	text-align: right;
-	padding-left: 10%;
-	padding-right: 15%;
-	max-width: auto;
-	min-height: auto;
-	text-align: center;
-	}
-
-#about {
-	max-width: 100%;
-	text-align: center;
-	background-color: #000000;
-}
 
 #about h2, #about h2.major {
 	color: #0196fd;
@@ -1743,18 +1690,25 @@ input, select, textarea {
 	text-align: left;
 }
 
+#pohl h3, #pohl h3.major,
+#imaginaryfriends h3, #imaginaryfriends h3.major,
+#rocio h3, #rocio h3.major,
+#about h3, #about h3.major,
 #credits h3, #credits h3.major,
 #recording-production h3, #recording-production h3.major {
 	border-bottom: solid 1px #0196fd;
 	color: #0196fd;
 	display: inline;
 	text-align: center;
-	font-size: 28px;
+	font-size: 18pt;
 }	
 
+#about p, #about p strong,
 #credits p, #credits p strong,
 #recording-production p, #recording-production p strong {
+	margin: 0 0 .66em 0;
 	color: #0196fd;
+	font-size: 14pt;
 }
 	/* End Custom CSS for Individual songs */
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 						<div class="content">
 							<div class="inner">
 								<h1>Where to Begin</h1>
-								<p>The <strong>debut EP</strong> by Tim Delaney</p>
+								<p>The <strong>debut EP</strong> by <strong><a href="https://timdelaneymusic.com">Tim Delaney</a></strong></p>
 							</div>
 						</div>
 						<nav>
@@ -42,22 +42,28 @@
 
 						<!-- Prints of Her Lipstick -->
 							<article id="pohl">
-								<h2 class="major">Prints of Her Lipstick</h2>
+								<h3 class="major">Prints of Her Lipstick</h3>
 								<br></br>
 								<!-- <span class="image main"><img src="images/lipstick.png" alt="" /></span> -->
 								<p class="lyrics">I don't know where to begin
 									<br>It feels like it never ends
 									<br>She says that she's into drugs
-									<br>And I think that I'm love
-									<br>It's the way she moves her hips
+									<br>And I think that I'm love</p>
+									<p>It's the way she moves her hips
 									<br>And what she does with her lips
 									<br>Each time she blows me a kiss
-									<br>It leaves some prints of her lipstick</br></p>
+									<br>It leaves some prints of her lipstick</p><br>
+								<ul class="icons">
+									<li><a href="#" class="icon brands fa-spotify"><span class="label">Spotify</span></a></li>
+									<li><a href="#" class="icon brands fa-apple"><span class="label">Apple Music</span></a></li>
+									<li><a href="#" class="icon brands fa-soundcloud"><span class="label">SoundCloud</span></a></li>
+									<li><a href="#" class="icon brands fa-youtube"><span class="label">Youtube</span></a></li>
+								</ul>
 							</article>
 
 						<!-- Imaginary Friends -->
 							<article id="imaginaryfriends">
-								<h2 class="major">Imaginary Friends</h2>
+								<h3 class="major">Imaginary Friends</h3>
 								<br></br>
 								<!-- <span class="image main"><img src="images/imaginaryfriends.png" alt="" /></span> -->
 								<p class="lyrics">Ooh that girl is fine
@@ -67,72 +73,86 @@
 									<br>After all we are just imaginary friends
 									<br>For as long as we pretend
 									<br>But I wish I were more than just an option to you girl
-									<br>And I wish I had known to use caution with you girl
-									<br>A serpent's word was clearly heard and set to disturb
+									<br>And I wish I had known to use caution with you girl</p>
+									<p>A serpent's word was clearly heard and set to disturb
 									<br>This course that has occurred
 									<br>But even if you were the first to commit sin girl
-									<br>All that occurs is a result of what's been girl
-									<br>And I will be your guilty pleasure
+									<br>All that occurs is a result of what's been girl</p>
+									<p>"And I will be your guilty pleasure
 									<br>And you could be my forbidden treasure
-									<br>And you could be mine</p>
+									<br>And you could be mine"</p><br>
+								<ul class="icons">
+									<li><a href="#" class="icon brands fa-spotify"><span class="label">Spotify</span></a></li>
+									<li><a href="#" class="icon brands fa-apple"><span class="label">Apple Music</span></a></li>
+									<li><a href="#" class="icon brands fa-soundcloud"><span class="label">SoundCloud</span></a></li>
+									<li><a href="#" class="icon brands fa-youtube"><span class="label">Youtube</span></a></li>
+								</ul>
 							</article>
 
 						<!-- Rocío -->
 							<article id="rocio">
-								<h2 class="major">Rocío</h2>
+								<h3 class="major">Rocío</h3>
 								<br></br>
 								<!-- <span class="image main"><img src="images/rocio.png" alt="" /></span> -->
 								<p class="lyrics">The morning dew forms on every blade of grass
-									<br>The day is new, another season has passed
-									<br>Passing through changeable states of being
-									<br>How can you believe anything you're seeing?
-									<br>The sky is blue, you fill my world with color
-									<br>The wind is cool, you make me feel like no other</br></p>
+									<br>The day is new, another season has passed</p>
+									<p>Passing through changeable states of being
+									<br>How can you believe anything you're seeing?</p>
+									<p>The sky is blue, you fill my world with color
+									<br>The wind is cool, you make me feel like no other</p><br>
+								<ul class="icons">
+									<li><a href="#" class="icon brands fa-spotify"><span class="label">Spotify</span></a></li>
+									<li><a href="#" class="icon brands fa-apple"><span class="label">Apple Music</span></a></li>
+									<li><a href="#" class="icon brands fa-soundcloud"><span class="label">SoundCloud</span></a></li>
+									<li><a href="#" class="icon brands fa-youtube"><span class="label">Youtube</span></a></li>
+								</ul>
 							</article>
 
 						<!-- About -->
 						<article id="about">
-							<h2 class="major">About</h2>
+							<h3 class="major">About</h3>
 							<br></br>
 							<!-- <span class="image main"><img src="images/pic03.jpg" alt="" /></span> -->
-							<p><strong>Where to Begin</strong> is the debut acoustic EP by <strong>Tim Delaney</strong>, released March 19, 2021.<br>
-								<br>In his own words…<br>
-								<br>I recorded Where to Begin largely in my closet between late 2016 and throughout 2017. At one point in 2017, I was working three different jobs, which slowed progress considerably. By 2018, I began working with Andre Moran on mixing, with Mark Hallman mastering the EP at Congress House Studio. That process unfolded over roughly eight sessions between December 2018 and March 2020.<br>
-								<br>“Imaginary Friends” was the first song I ever wrote on guitar after learning to play in early 2012, while “Rocío” was written during a period I spent living in New York City in 2013. “Prints of Her Lipstick” originally began as part of a different song altogether, but gradually evolved into what it ultimately became on the EP.<br>
-								<br>Both “Prints of Her Lipstick” and “Imaginary Friends” rely on a simple, circular structure rather than a traditional verse-chorus format. In “Prints of Her Lipstick,” certain vocal inflections and elongated consonants became more pronounced during recording, adding a subtle sense of tension and intimacy to the delivery. While this wasn’t something I consciously planned, it emerged naturally in production and felt emotionally consistent with the song’s subject matter.<br>
-								<br>“Rocío,” by contrast, features a more openly evolving chorus and is built around a four-chord progression. If you listen closely, you can hear me clear my throat in the middle of the first chorus—an unintentional moment I chose to leave in. The birds heard before and after the song were recorded at the corner of Woodward and Palmetto in Ridgewood, Queens, and serve as a personal transitional texture, connecting my time in New York to my life as an artist in Austin.<br>
-								<br>For the first three songs, my original intention was to record something very raw, inspired by the stark simplicity of The Paul Simon Songbook. As the sessions developed, though, I found myself drawn to the textures created by layered harmonies, ukulele, and light percussion. I allowed the arrangements to expand naturally, with the only real constraint being the exclusive use of acoustic instruments.<br>
-								<br>“The Man I’ve Been” was recorded much earlier, on May 7, 2008, at my first apartment in Austin. It was written by my late friend and gifted songwriter and musician Jon Pettis, to whom this EP is dedicated. The recording was entirely on-the-fly and unrehearsed, with friends present in the room. I included it because it felt emotionally aligned with the rest of the EP and because it represents one of the first pieces of music I ever recorded. I’ve always loved how it came out—it almost feels like you’re sitting in the living room with us.
+							<p><strong>Where to Begin</strong> is the debut acoustic EP by <strong>Tim Delaney</strong>, released March 19, 2021.</p>
+								<p>In his own words…</p>
+								<p>I recorded Where to Begin largely in my closet between late 2016 and throughout 2017. At one point in 2017, I was working three different jobs, which slowed progress considerably. By 2018, I began working with Andre Moran on mixing, with Mark Hallman mastering the EP at Congress House Studio. That process unfolded over roughly eight sessions between December 2018 and March 2020.</p>
+								<p>“Imaginary Friends” was the first song I ever wrote on guitar after learning to play in early 2012, while “Rocío” was written during a period I spent living in New York City in 2013. “Prints of Her Lipstick” originally began as part of a different song altogether, but gradually evolved into what it ultimately became on the EP.</p>
+								<p>Both “Prints of Her Lipstick” and “Imaginary Friends” rely on a simple, circular structure rather than a traditional verse-chorus format. In “Prints of Her Lipstick,” certain vocal inflections and elongated consonants became more pronounced during recording, adding a subtle sense of tension and intimacy to the delivery. While this wasn’t something I consciously planned, it emerged naturally in production and felt emotionally consistent with the song’s subject matter.</p>
+								<p>“Rocío,” by contrast, features a more openly evolving chorus and is built around a four-chord progression. If you listen closely, you can hear me clear my throat in the middle of the first chorus—an unintentional moment I chose to leave in. The birds heard before and after the song were recorded at the corner of Woodward and Palmetto in Ridgewood, Queens, and serve as a personal transitional texture, connecting my time in New York to my life as an artist in Austin.</p>
+								<p>For the first three songs, my original intention was to record something very raw, inspired by the stark simplicity of The Paul Simon Songbook. As the sessions developed, though, I found myself drawn to the textures created by layered harmonies, ukulele, and light percussion. I allowed the arrangements to expand naturally, with the only real constraint being the exclusive use of acoustic instruments.</p>
+								<p>“The Man I’ve Been” was recorded much earlier, on May 7, 2008, at my first apartment in Austin. It was written by my late friend and gifted songwriter and musician Jon Pettis, to whom this EP is dedicated. The recording was entirely on-the-fly and unrehearsed, with friends present in the room. I included it because it felt emotionally aligned with the rest of the EP and because it represents one of the first pieces of music I ever recorded. I’ve always loved how it came out—it almost feels like you’re sitting in the living room with us.</p>
 							<section id="recording-production">		
 								<h3 class="major">Recording & Production</h3><br><br>
-									<p>Prints of Her Lipstick / Imaginary Friends / Rocío<br>
-									<br>Multi-track recordings captured to an automated click track in the closet of Delaney’s residence between December 2016 and 2017.<br>
+									<p><strong>Prints of Her Lipstick / Imaginary Friends / Rocío</strong></p>
+									<p>Multi-track recordings captured to an automated click track in the closet of Delaney’s residence between December 2016 and 2017.</p>
 									<!-- <br>Gear and software:
 									<br>Microphone: AKG C414 XLII
 									<br>Interface: MBox 3 Pro
 									<br>DAW: Pro Tools 10<br> -->
-									<br>Instrumentation:
+									<p><strong>Instrumentation:</strong>
 									<br>Acoustic guitar
 									<br>Lead and backing vocals
 									<br>Ukulele
 									<br>Rainstick
 									<br>Tambourines (2)
 									<br>Homemade shaker (Crown Royal bag filled with bottle caps and pennies)
-									<br>Nutshell shaker previously used in a burial ceremony, originally belonging to a Huichol Tribe shaman (used on Prints of Her Lipstick and Imaginary Friends)<br>
-									<br>Did This Already Happen? / The Man I’ve Been<br>
-									<br>Mono recordings captured live in the living room of Delaney’s first apartment in Austin, TX, in 2008.<br>
+									<br>Nutshell shaker previously used in a burial ceremony, originally belonging to a Huichol Tribe shaman (used on Prints of Her Lipstick and Imaginary Friends)</p>
+									
+									<p><strong>Did This Already Happen? / The Man I’ve Been</strong></p>
+									<p>Mono recordings captured live in the living room of Delaney’s first apartment in Austin, TX, in 2008.</p>
 									<!-- <br>Gear and software:
 									<br>Microphone: Nady CM88
 									<br>Interface: MBox 2
 									<br>DAW: Pro Tools 7 LE<br> -->
-									<br>Instrumentation:
+									<p><strong>Instrumentation:</strong>
 									<br>Acoustic guitar
 									<br>Lead vocals
 									<br>Drum kit with brushes
 									<br>Bongos
-									<br>Hand claps<br>
-									<br>Field Recordings<br>
-									<br>Bird ambience recorded at the corner of Woodward Avenue and Palmetto Street, Ridgewood, Queens, New York, NY.</p>
+									<br>Hand claps</p>
+									
+									<p><strong>Field Recordings</strong></p>
+									<p>Bird ambience recorded at the corner of Woodward Avenue and Palmetto Street, Ridgewood, Queens, New York, NY.</p>
 									<!-- <br>Gear and software:
 									<br>Microphone: MXL 4000
 									<br>Preamp: Presonus BlueTube
@@ -142,19 +162,23 @@
 							<section id="credits">
 								<h3 class="major">Credits</h3>
 								<br></br>
-								<p>"<strong>Prints of Her Lipstick</strong>“, “<strong>Imaginary Friends</strong>,” and “<strong>Rocío</strong>”<br>
-									<br>Written and performed by Tim Delaney
-									<br>Featuring Mary Beth Widhalm (vocals) on Imaginary Friends<br>
-									<br>“<strong>Did This Already Happen?</strong>”<br>
-									<br>Opening dialogue between Gene Griffin and Jon Pettis
-									<br>Monologue by Blue Mongeon<br>
-									<br>“<strong>The Man I’ve Been</strong>” Written by Jon Pettis<br>
+								<p><strong>Prints of Her Lipstick / Imaginary Friends / Rocío</strong></p>
+									<p>Written and performed by Tim Delaney
+									<br>Featuring Mary Beth Widhalm (vocals) on Imaginary Friends</p>
+									
+									<p><strong>Did This Already Happen?</strong></p>
+									<p>Opening dialogue between Gene Griffin and Jon Pettis
+									<br>Monologue by Blue Mongeon</p>
+									
+									<p><strong>The Man I’ve Been</strong></p> 
+									<p>Written by Jon Pettis
 									<br>Performed by:
 									<br>Jon Pettis — guitar, vocals
 									<br>Tim Delaney — drums
 									<br>Blue Mongeon — mouthing sax, backing vocals, hand claps
-									<br>Gene Griffin — bongos, hand claps<br>
-									<br>All songs recorded and produced by Tim Delaney.</p>
+									<br>Gene Griffin — bongos, hand claps</p>
+									
+									<p>All songs recorded and produced by Tim Delaney.</p>
 
 							</section>
 						</article>
@@ -164,7 +188,7 @@
 				<!-- Footer -->
 					<footer id="footer">
 						<ul class="copyright">
-							&copy; 2021-<span id="currentYear"></span> Hearing Colors LLC. All rights reserved.
+							&copy; 2021-<span id="currentYear"></span> <a href="https://hearingcolors.com">Hearing Colors LLC</a>. All rights reserved.
 							<script>
 								const currentYear = new Date().getFullYear();
 								document.getElementById('currentYear').textContent = currentYear;


### PR DESCRIPTION
**Changes
CSS: Consolidation + typography consistency (assets/css/main.css)**

- Consolidated duplicated styling for EP sections by applying shared rules across #pohl, #imaginaryfriends, #rocio, and #about.
- Standardized heading styles across track sections (moved tracks to use consistent heading rules).
- Normalized lyric/body text styling:
- Reduced font size to 14pt
- Unified padding to 10% left/right for better line length
- Added consistent paragraph spacing (margin: 0 0 .66em 0)
- Extended consistent h3.major styling across song sections + About/Credits/Recording sections and adjusted sizing to 18pt.
- Updated About/Credits/Recording paragraph styles to match the new typography and spacing baseline.

**HTML: Track presentation + content formatting (index.html)**

- Linked the “debut EP by Tim Delaney” credit line to Tim’s site.
- Changed track titles from h2.major to h3.major for consistent hierarchy/styling.
- Broke long lyric blocks into smaller paragraph chunks for better reading rhythm.
- Added platform icon rows (Spotify / Apple Music / SoundCloud / YouTube) under each of the three tracks.
- Refactored the About section from <br>-heavy formatting into clean paragraph structure.
- Reworked Recording & Production into clearer sub-sections (bold headings + separate paragraphs for instrumentation / field recordings).
- Restructured Credits into grouped blocks per track cluster, with clearer separation and scanability.
- Added a link to Hearing Colors in the footer copyright line.
- 

**Notes / impact**

- This is primarily presentation and content structure work (no new JS logic).
- Platform icons are currently placeholder href="#" links—ready to be wired to real URLs when you have them.